### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build (template)
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/eumel8/capi-advisor/security/code-scanning/2](https://github.com/eumel8/capi-advisor/security/code-scanning/2)

To fix the problem, explicitly define a `permissions` block in the workflow. The minimal, least-privilege fix is to set the permissions at the workflow root so they're enforced for all jobs that do not define their own permissions (and are inherited by the `call-workflow` job). Since no information was provided regarding required write actions, we should set `contents: read` as a sane default, adhering to GitHub's minimum required permissions. Edit `.github/workflows/build.yml` and insert a `permissions` block after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
